### PR TITLE
hypothesis appears to require 3.6.2+ of python

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      # specify the version you desire here
-      # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: circleci/python:3.6.1
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
+      - image: circleci/python:3.6.10
 
     working_directory: ~/repo
 


### PR DESCRIPTION
See the following failure:
E.................................
======================================================================
ERROR: tests.test_consistent (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: tests.test_consistent
Traceback (most recent call last):
  File /usr/local/lib/python3.6/unittest/loader.py, line 428, in _find_test_path
    module = self._get_module_from_name(name)
  File /usr/local/lib/python3.6/unittest/loader.py, line 369, in _get_module_from_name
    __import__(name)
  File /home/circleci/repo/tests/test_consistent.py, line 3, in <module>
    from hypothesis import given
  File /home/circleci/repo/venv/lib/python3.6/site-packages/hypothesis/__init__.py, line 25, in <module>
    from hypothesis.control import (
  File /home/circleci/repo/venv/lib/python3.6/site-packages/hypothesis/control.py, line 18, in <module>
    from typing import NoReturn, Union
ImportError: cannot import name 'NoReturn'